### PR TITLE
Set rpath to include mac bundle Frameworks

### DIFF
--- a/py2app/apptemplate/setup.py
+++ b/py2app/apptemplate/setup.py
@@ -33,7 +33,7 @@ gPreBuildVariants = [
     {
         "name": "main-x86_64",
         "target": "10.5",
-        "cflags": "-g -arch x86_64",
+        "cflags": "-g -arch x86_64 -Wl,-rpath,@executable_path/../Frameworks",
         "cc": "/usr/bin/clang",
     },
     {


### PR DESCRIPTION
Adds a `LC_RPATH` to executable so that libraries that use  `@rpath` can be found in the bundle.
```
$ otool -l MyApp.app/Contents/MacOS/myapp
Load command ..
          cmd LC_RPATH
      cmdsize 48
         path @executable_path/../Frameworks (offset 12)
```

Helps with https://github.com/ronaldoussoren/py2app/issues/286#issuecomment-692597331

I tested this on `10.14.6 (18G6032)`