### PR TITLE
Fix Help for IPython

### DIFF
--- a/py2app/apptemplate/lib/site.py
+++ b/py2app/apptemplate/lib/site.py
@@ -142,3 +142,7 @@ except ImportError:
 #
 if hasattr(sys, "setdefaultencoding"):
     del sys.setdefaultencoding
+
+import builtins
+import _sitebuiltins
+builtins.help = _sitebuiltins._Helper()

--- a/py2app/bundletemplate/lib/site.py
+++ b/py2app/bundletemplate/lib/site.py
@@ -58,6 +58,7 @@ for dir in sys.path:
     if dircase not in _dirs_in_sys_path:
         L.append(dir)
         _dirs_in_sys_path[dircase] = 1
+
 sys.path[:] = L
 del dir, dircase, L
 _dirs_in_sys_path = None
@@ -141,3 +142,7 @@ except ImportError:
 #
 if hasattr(sys, "setdefaultencoding"):
     del sys.setdefaultencoding
+
+import builtins
+import _sitebuiltins
+builtins.help = _sitebuiltins._Helper()

--- a/py2app/recipes/__init__.py
+++ b/py2app/recipes/__init__.py
@@ -22,3 +22,4 @@ from . import tkinter  # noqa: F401
 from . import virtualenv  # noqa: F401
 from . import wx  # noqa: F401
 from . import xml  # noqa: F401
+from . import ipython  # noqa: F401

--- a/py2app/recipes/ipython.py
+++ b/py2app/recipes/ipython.py
@@ -1,0 +1,6 @@
+def check(cmd, mf):
+    m = mf.findNode("IPython")
+    if m is None or m.filename is None:
+        return None
+
+    return {"includes": ['_sitebuiltins']}


### PR DESCRIPTION
Resolves #337 
The standard `site.py` file for vanilla Python includes a definition for `builtins.help` that is not included in `py2app`'s `site.py` template, but is necessary for IPython. Additionally, an IPython recipe is provided to ensure that `_sitebuiltins` is included in the build.

Note that `_sitebuiltins` only needs to be included, it does not need to be listed with packages (outside zip directory). Including it in the `automissing` recipe did not seem to work, so I created a recipe for IPython instead.

@ronaldoussoren, what do you think?