### PR TITLE
Add recipe for platformdirs

### DIFF
--- a/py2app/recipes/__init__.py
+++ b/py2app/recipes/__init__.py
@@ -23,3 +23,4 @@ from . import tkinter  # noqa: F401
 from . import virtualenv  # noqa: F401
 from . import wx  # noqa: F401
 from . import xml  # noqa: F401
+from . import platformdirs  # noqa: F401

--- a/py2app/recipes/platformdirs.py
+++ b/py2app/recipes/platformdirs.py
@@ -1,0 +1,8 @@
+def check(cmd, mf):
+    m = mf.findNode("platformdirs")
+    if m is None or m.filename is None:
+        return None
+
+    includes = ['platformdirs.macos']
+
+    return {"includes": includes}


### PR DESCRIPTION
platformdirs uses importlib to import platform specific modules. py2app should only require that platformdirs.macos is included.