### PR TITLE
update pygame recipe to remove missing icon

### DIFF
--- a/py2app/recipes/pygame.py
+++ b/py2app/recipes/pygame.py
@@ -9,5 +9,5 @@ def check(cmd, mf):
     def addpath(f):
         return os.path.join(os.path.dirname(m.filename), f)
 
-    RESOURCES = ["freesansbold.ttf", "pygame_icon.tiff", "pygame_icon.icns"]
+    RESOURCES = ["freesansbold.ttf", "pygame_icon.icns"]
     return {"loader_files": [("pygame", map(addpath, RESOURCES))]}


### PR DESCRIPTION
the tiff file is no longer present after pygame 2.1.1

c.f. this PR: https://github.com/pygame/pygame/pull/2858

possibly we could add `pygame_icon_mac.bmp` in its place but I'm pretty sure that file is not used at runtime, it's a built artifact?