### PR TITLE
typo in NamedTemporaryFile

### DIFF
--- a/py2app/util.py
+++ b/py2app/util.py
@@ -393,7 +393,7 @@ def byte_compile(
         if verbose:
             print("writing byte-compilation script")
         if not dry_run:
-            with NamedTemporaryFile(sufix=".py", delete=False) as script:
+            with NamedTemporaryFile(suffix=".py", delete=False) as script:
                 script_name = script.name
                 script.write(
                     """

--- a/py2app/util.py
+++ b/py2app/util.py
@@ -393,7 +393,8 @@ def byte_compile(
         if verbose:
             print("writing byte-compilation script")
         if not dry_run:
-            with NamedTemporaryFile(suffix=".py", delete=False) as script:
+            with NamedTemporaryFile(suffix=".py", delete=False, mode="w", 
+                    encoding="utf-8") as script:
                 script_name = script.name
                 script.write(
                     """


### PR DESCRIPTION
Fixes the typo on creating a NamedTemporaryFile. Should fix the following

`writing byte-compilation script
Traceback (most recent call last):
  File "/Users/luther/Documents/Projects/Artisan/Repository/artisan/src/setup-mac3.py", line 165, in <module>
    setup(
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/setuptools/__init__.py", line 155, in setup
    return distutils.core.setup(**attrs)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 148, in setup
    return run_commands(dist)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/setuptools/_distutils/core.py", line 163, in run_commands
    dist.run_commands()
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 967, in run_commands
    self.run_command(cmd)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/setuptools/_distutils/dist.py", line 986, in run_command
    cmd_obj.run()
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/py2app/build_app.py", line 932, in run
    self._run()
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/py2app/build_app.py", line 1162, in _run
    self.run_normal()
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/py2app/build_app.py", line 1275, in run_normal
    self.create_binaries(py_files, pkgdirs, extensions, loader_files)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/py2app/build_app.py", line 1571, in create_binaries
    byte_compile(
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/py2app/util.py", line 396, in byte_compile
    with NamedTemporaryFile(sufix=".py", delete=False) as script:
TypeError: NamedTemporaryFile() got an unexpected keyword argument 'sufix'`