### PR TITLE
BUGFIX: rpath for all architectures

### DIFF
--- a/src/py2app/apptemplate/setup.py
+++ b/src/py2app/apptemplate/setup.py
@@ -8,13 +8,13 @@ gPreBuildVariants = [
     {
         "name": "main-universal2",
         "target": "10.9",
-        "cflags": "-g -arch arm64 -arch x86_64",
+        "cflags": "-g -arch arm64 -arch x86_64 -Wl,-rpath,@executable_path/../Frameworks",
         "cc": "/usr/bin/clang",
     },
     {
         "name": "main-arm64",
         "target": "10.16",
-        "cflags": "-g -arch arm64",
+        "cflags": "-g -arch arm64 -Wl,-rpath,@executable_path/../Frameworks",
         "cc": "/usr/bin/clang",
     },
     {


### PR DESCRIPTION
Fix an oversight which has exited since #315

Untested (as-of), but this has to be the solution — #482 also mentions that they are on Apple Silicon, like me.

Closes: #482, #286, #472