### PR TITLE
Cleanup build_app.py

### DIFF
--- a/src/py2app/build_app.py
+++ b/src/py2app/build_app.py
@@ -809,10 +809,9 @@ class py2app(Command):
         if version is None:
             version = sys.version
         version = ".".join(version.split(".")[:2])
-        info = None
 
         try:
-            fmwk = macholib.dyld.framework_find(os.fspath(prefix))
+            fmwk = macholib.dyld.framework_find(prefix)
         except ValueError:
             info = None
         else:
@@ -821,7 +820,7 @@ class py2app(Command):
         if info is not None:
             dylib = info["name"]
             runtime = os.path.join(info["location"], info["name"])
-        else:
+        else: # For Anaconda Python Environments
             dylib = "libpython%d.%d.dylib" % (sys.version_info[:2])
             runtime = os.path.join(prefix, "lib", dylib)
 

--- a/src/py2app/build_app.py
+++ b/src/py2app/build_app.py
@@ -805,35 +805,11 @@ class py2app(Command):
         # XXX: this is a bit of a hack!
         # ideally we'd use dylib functions to figure this out
         if prefix is None:
-            prefix = sys.prefix
+            prefix = sys.base_prefix
         if version is None:
             version = sys.version
         version = ".".join(version.split(".")[:2])
         info = None
-        if sys.base_prefix != sys.prefix:
-            prefix = sys.base_prefix
-
-        elif os.path.exists(os.path.join(prefix, "pyvenv.cfg")):
-            with open(os.path.join(prefix, "pyvenv.cfg")) as fp:
-                for ln in fp:
-                    if ln.startswith("home = "):
-                        _, home_path = ln.split("=", 1)
-                        prefix = os.path.dirname(home_path.strip())
-                        break
-                else:
-                    raise DistutilsPlatformError(
-                        "Pyvenv detected, cannot determine base prefix"
-                    )
-
-        elif os.path.exists(os.path.join(prefix, ".Python")):
-            # We're in a virtualenv environment, locate the real prefix
-            fn = os.path.join(
-                prefix, "lib", "python%d.%d" % (sys.version_info[:2]), "orig-prefix.txt"
-            )
-
-            if os.path.exists(fn):
-                with open(fn) as fp:
-                    prefix = fp.read().strip()
 
         try:
             fmwk = macholib.dyld.framework_find(os.fspath(prefix))

--- a/src/py2app/build_app.py
+++ b/src/py2app/build_app.py
@@ -122,10 +122,6 @@ PLUGIN_SUFFIXES = {
     ".action": "Automator",
 }
 
-
-sys_base_prefix = sys.base_prefix
-
-
 def finalize_distribution_options(dist: Py2appDistribution) -> None:
     """
     setuptools.finalize_distribution_options extension
@@ -605,8 +601,8 @@ class py2app(Command):
     def finalize_options(self) -> None:
         self.progress = Progress()
 
-        if sys_base_prefix != sys.prefix:
-            self._python_app = os.path.join(sys_base_prefix, "Resources", "Python.app")
+        if sys.base_prefix != sys.prefix:
+            self._python_app = os.path.join(sys.base_prefix, "Resources", "Python.app")
 
         elif os.path.exists(os.path.join(sys.prefix, "pyvenv.cfg")):
             with open(os.path.join(sys.prefix, "pyvenv.cfg")) as fp:
@@ -814,8 +810,8 @@ class py2app(Command):
             version = sys.version
         version = ".".join(version.split(".")[:2])
         info = None
-        if sys_base_prefix != sys.prefix:
-            prefix = sys_base_prefix
+        if sys.base_prefix != sys.prefix:
+            prefix = sys.base_prefix
 
         elif os.path.exists(os.path.join(prefix, "pyvenv.cfg")):
             with open(os.path.join(prefix, "pyvenv.cfg")) as fp:

--- a/src/py2app/build_app.py
+++ b/src/py2app/build_app.py
@@ -122,6 +122,7 @@ PLUGIN_SUFFIXES = {
     ".action": "Automator",
 }
 
+
 def finalize_distribution_options(dist: Py2appDistribution) -> None:
     """
     setuptools.finalize_distribution_options extension
@@ -783,7 +784,7 @@ class py2app(Command):
         if info is not None:
             dylib = info["name"]
             runtime = os.path.join(info["location"], info["name"])
-        else: # For Anaconda Python Environments
+        else:  # For Anaconda Python Environments
             dylib = "libpython%d.%d.dylib" % (sys.version_info[:2])
             runtime = os.path.join(prefix, "lib", dylib)
 

--- a/src/py2app/build_app.py
+++ b/src/py2app/build_app.py
@@ -1665,28 +1665,6 @@ class py2app(Command):
                     sfile = os.path.join(dpath, "Python")
                 self.copy_file(sfile, execdst)
                 make_exec(execdst)
-
-            elif os.path.exists(os.path.join(sys.prefix, ".Python")):
-                fn = os.path.join(
-                    sys.prefix,
-                    "lib",
-                    "python%d.%d" % (sys.version_info[:2]),
-                    "orig-prefix.txt",
-                )
-
-                if os.path.exists(fn):
-                    with open(fn) as fp:
-                        prefix = fp.read().strip()
-
-                rest_path = os.path.normpath(sys.executable)[
-                    len(os.path.normpath(sys.prefix)) + 1 :  # noqa: E203
-                ]
-                if rest_path.startswith("."):
-                    rest_path = rest_path[1:]
-
-                self.copy_file(os.path.join(prefix, rest_path), execdst)
-                make_exec(execdst)
-
             else:
                 self.copy_file(sys.executable, execdst)
                 make_exec(execdst)


### PR DESCRIPTION
With the introduction of sys.base_prefix a while ago, some code has become redundant, doing exactly what sys.base_prefix is for. This pr should have no functionality changes, but makes the code (slightly) more readable.
