### PR TITLE
BUGFIX: copy dylibs

### DIFF
--- a/src/py2app/apptemplate/setup.py
+++ b/src/py2app/apptemplate/setup.py
@@ -20,7 +20,7 @@ gPreBuildVariants = [
     {
         "name": "main-x86_64",
         "target": "10.5",
-        "cflags": "-g -arch x86_64 -Wl,-rpath,@executable_path/../Frameworks",
+        "cflags": "-g -arch x86_64",
         "cc": "/usr/bin/clang",
     },
 ]

--- a/src/py2app/build_app.py
+++ b/src/py2app/build_app.py
@@ -1741,6 +1741,12 @@ class py2app(Command):
                 mm.excludes.append(runtime)
             else:
                 mm.mm.run_file(runtime)
+
+            dylib_dir = os.path.dirname(runtime)
+            for fn in os.listdir(dylib_dir):
+                if fn.endswith(".dylib"):
+                    mm.mm.run_file(os.path.join(dylib_dir, fn))
+
             for exclude in self.dylib_excludes:
                 info = macholib.dyld.framework_info(exclude)
                 if info is not None:


### PR DESCRIPTION
A rough patch copying all dylibs available in the runtime into the app. This should close most issues that #502 was intended to fix. 

Tested in standalone mode, Anaconda python installation, Apple Silicon.

Reverts #315 (it never helped and only affected x86 architecture; #502 was supposed to port the fix to other architectures, and it definitely did not resolve the bug).
Closes: #494 #482 #286 #472

The behaviour exhibited only fits the default standalone mode; not alias mode and probably not semi-standalone mode. It's hell to test a project where you aren't sure whether the problem is in the modified code, versioning, or an original bug, and I haven't even touched the other modes yet, so I'm hoping a maintainer will adapt this code to how it should be.
