### PR TITLE
PLEASE TEST: confirm regression for x86 architecture

### DIFF
--- a/src/py2app/apptemplate/setup.py
+++ b/src/py2app/apptemplate/setup.py
@@ -20,7 +20,7 @@ gPreBuildVariants = [
     {
         "name": "main-x86_64",
         "target": "10.5",
-        "cflags": "-g -arch x86_64 -Wl,-rpath,@executable_path/../Frameworks",
+        "cflags": "-g -arch x86_64",
         "cc": "/usr/bin/clang",
     },
 ]


### PR DESCRIPTION
This is to test that some bugs ARE fixed by this statement; *should only affect x86 
architecture*.
Reverts #315 for x86
Please confirm that this creates a regression similar to #494, #482, #286 or #472.
