### PR TITLE
qualify Distribution by module name pkg_resources

### DIFF
--- a/src/py2app/recipes/setuptools.py
+++ b/src/py2app/recipes/setuptools.py
@@ -21,7 +21,7 @@ PRESCRIPT = textwrap.dedent(
 
         metadata = pkg_resources.EggMetadata(importer)
         if metadata.has_metadata('PKG-INFO'):
-            yield Distribution.from_filename(path_item, metadata=metadata)
+            yield pkg_resources.Distribution.from_filename(path_item, metadata=metadata)
         for subitem in metadata.resource_listdir(''):
             if not only and pkg_resources._is_egg_path(subitem):
                 subpath = os.path.join(path_item, subitem)


### PR DESCRIPTION
The seems to be a typo in `recipes/setuptools.py` quite for a while which results in

```
File /Applications/MyApp.app/Contents/Resources/__boot__.py", line 233, in find_eggs_in_zip
  yield Distribution.from_filename(path_item, metadata=metadata)
           ^^^^^^^^^
NameError: name 'Distribution' is not defined
2024-02-08 20:03:56.471 MyApp[63203:14701403] Launch error 
See the py2app website for debugging launch issues
```