### PR TITLE
honor PY2APP_SIGNING_IDENTITY environment variable for codesigning

### DIFF
--- a/src/py2app/util.py
+++ b/src/py2app/util.py
@@ -663,7 +663,7 @@ def _dosign(
             (
                 "codesign",
                 "-s",
-                "-",
+                os.environ.get("PY2APP_SIGNING_IDENTITY", "-"),
                 "--preserve-metadata=identifier,entitlements,flags,runtime",
                 "-f",
             )


### PR DESCRIPTION
An extremely simplistic fix, just for discussion purposes

fixes #544 