### PR TITLE
Use context manager in PIL example

### DIFF
--- a/examples/PIL/hello.py
+++ b/examples/PIL/hello.py
@@ -23,6 +23,6 @@ def somefunc():
 
 if __name__ == "__main__":
     somefunc()
-    img = PIL.Image.open(PATH)
-    print(type(img))
-    print(img.size)
+    with PIL.Image.open(PATH) as img:
+        print(type(img))
+        print(img.size)


### PR DESCRIPTION
Minor suggestion. https://pillow.readthedocs.io/en/stable/releasenotes/7.0.0.html#image-del removed official support for implicitly closing an image, instead suggesting either explicitly closing an image or using context managers.