### PR TITLE
Allow pre-commit workflow to be manually triggered

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
   pre-commit:


### PR DESCRIPTION
I'm not sure what your rationale was for only running the pre-commit workflow on master was, but I think it would be helpful to be able to run it manually on branches.

Perhaps a middle ground would be to add [`workflow_dispatch`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch)?