### PR TITLE
Remove use of imp

### DIFF
--- a/src/py2app/build_app.py
+++ b/src/py2app/build_app.py
@@ -7,7 +7,7 @@ Originally (loosely) based on code from py2exe's build_exe.py by Thomas Heller.
 # mypy: ignore-errors
 
 import collections
-import imp
+import importlib.machinery
 import io
 import itertools
 import os
@@ -1769,9 +1769,7 @@ class py2app(Command):
         This is a bit of a hack, it would be better to identify python eggs
         and copy those in whole.
         """
-        exts = [i[0] for i in imp.get_suffixes()]
-        exts.append(".py")
-        exts.append(".pyc")
+        exts = importlib.machinery.all_suffixes()
         exts.append(".pyo")
 
         def datafilter(item: str) -> bool:

--- a/src/py2app/recipes/virtualenv.py
+++ b/src/py2app/recipes/virtualenv.py
@@ -8,7 +8,6 @@ This recipe is rather complicated and definitely not a
 good model for other recipes!!!
 """
 
-import imp
 import os
 import sys
 import typing
@@ -50,7 +49,7 @@ def retry_import(mf: ModuleGraph, m: Node) -> typing.Optional[Node]:
     ]:
         if path is None:
             if name in sys.builtin_module_names:
-                return (None, None, ("", "", imp.C_BUILTIN))
+                return (None, None, ("", "", 6))  # imp.C_BUILTIN
 
             path = mf.path
 
@@ -66,9 +65,9 @@ def retry_import(mf: ModuleGraph, m: Node) -> typing.Optional[Node]:
     except ImportError:
         return None
 
-    if stuff[-1] == imp.PKG_DIRECTORY:
+    if stuff[-1] == 5:  # imp.PKG_DIRECTORY
         m.__class__ = Package
-    elif stuff[-1] == imp.PY_SOURCE:
+    elif stuff[-1] == 1:  # imp.PY_SOURCE
         m.__class__ = SourceModule
     else:
         m.__class__ = CompiledModule

--- a/src/py2app/util.py
+++ b/src/py2app/util.py
@@ -13,6 +13,9 @@ import time
 import typing
 from py_compile import compile  # noqa: A004
 
+from importlib._bootstrap import _load
+import importlib.machinery
+
 import macholib.util
 from macholib.util import is_platform_file
 from modulegraph import zipio
@@ -317,7 +320,9 @@ def __load():
             continue
         ext_path = os.path.join(path, ext)
         if os.path.exists(ext_path):
-            mod = imp.load_dynamic(__name__, ext_path)
+            loader = importlib.machinery.ExtensionFileLoader(__name__, ext_path)
+            spec = importlib.machinery.ModuleSpec(name=__name__, loader=loader, origin=ext_path)
+            mod = _load(spec)
             break
     else:
         raise ImportError(repr(ext) + " not found")


### PR DESCRIPTION
Helps Python 3.12 support, after imp was removed from that version.