### PR TITLE
Python 3.8 is the minimum supported version

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -30,7 +30,7 @@
       :link-type: doc
 
       - macOS 10.9 and later
-      - Python 3.7 and later
+      - Python 3.8 and later
       - x86_64 and arm64
 
    .. grid-item-card:: Installing py2app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Based on
https://github.com/ronaldoussoren/py2app/blob/487a55e34746fa6eb857de51f2bd0ac03026592d/pyproject.toml#L12
Python 3.8 is the minimum supported version.